### PR TITLE
Prevent ErrorException when 0 results

### DIFF
--- a/src/Services/Cloudflare.php
+++ b/src/Services/Cloudflare.php
@@ -45,10 +45,14 @@ class Cloudflare
                 return [
                     $key => [
                         'requests' => $item->sum(static function (array $item) {
-                            return $item['httpRequests1dGroups'][0]['sum']['requests'] ?: 0;
+                            return !empty($item['httpRequests1dGroups'][0]['sum']['requests']) 
+                                ? $item['httpRequests1dGroups'][0]['sum']['requests'] 
+                                : 0;
                         }),
                         'bytes' => $item->sum(static function (array $item) {
-                            return $item['httpRequests1dGroups'][0]['sum']['bytes'] ?: 0;
+                            return !empty($item['httpRequests1dGroups'][0]['sum']['bytes']) 
+                                ? $item['httpRequests1dGroups'][0]['sum']['bytes'] 
+                                : 0;
                         }),
                     ],
                 ];

--- a/src/Services/Cloudflare.php
+++ b/src/Services/Cloudflare.php
@@ -48,9 +48,7 @@ class Cloudflare
                             return $item['httpRequests1dGroups'][0]['sum']['requests'] ?? 0;
                         }),
                         'bytes' => $item->sum(static function (array $item) {
-                            return !empty($item['httpRequests1dGroups'][0]['sum']['bytes']) 
-                                ? $item['httpRequests1dGroups'][0]['sum']['bytes'] 
-                                : 0;
+                            return $item['httpRequests1dGroups'][0]['sum']['bytes'] ?? 0;
                         }),
                     ],
                 ];

--- a/src/Services/Cloudflare.php
+++ b/src/Services/Cloudflare.php
@@ -45,9 +45,7 @@ class Cloudflare
                 return [
                     $key => [
                         'requests' => $item->sum(static function (array $item) {
-                            return !empty($item['httpRequests1dGroups'][0]['sum']['requests']) 
-                                ? $item['httpRequests1dGroups'][0]['sum']['requests'] 
-                                : 0;
+                            return $item['httpRequests1dGroups'][0]['sum']['requests'] ?? 0;
                         }),
                         'bytes' => $item->sum(static function (array $item) {
                             return !empty($item['httpRequests1dGroups'][0]['sum']['bytes']) 


### PR DESCRIPTION
Prevent ErrorException when 0 results of valid domains. 


```
  ErrorException 

  Undefined offset: 0

  at vendor/owenvoke/laravel-dashboard-cloudflare-stats-tile/src/Services/Cloudflare.php:48
     44▕             ->flatMap(static function (Collection $item, $key) {
     45▕                 return [
     46▕                     $key => [
     47▕                         'requests' => $item->sum(static function (array $item) {
  ➜  48▕                             return $item['httpRequests1dGroups'][0]['sum']['requests'] ?: 0;
     49▕                         }),
     50▕                         'bytes' => $item->sum(static function (array $item) {
     51▕                             return $item['httpRequests1dGroups'][0]['sum']['bytes'] ?: 0;
     52▕                         }),

      +2 vendor frames 
```

<!--- Provide a general summary of your changes in the Title above -->

...

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
